### PR TITLE
Disable GCC_NO_COMMON_BLOCKS setting

### DIFF
--- a/aerogear-otp.ios.xcodeproj/project.pbxproj
+++ b/aerogear-otp.ios.xcodeproj/project.pbxproj
@@ -385,6 +385,7 @@
 			baseConfigurationReference = EDEE05E304D7DD67AD2F7F2B /* Pods-aerogear-otp.iosTests.release.xcconfig */;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				GCC_NO_COMMON_BLOCKS = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "aerogear-otp.ios/aerogear-otp.ios-Prefix.pch";
 				INFOPLIST_FILE = "aerogear-otp.iosTests/aerogear-otp.iosTests-Info.plist";
@@ -513,6 +514,7 @@
 			baseConfigurationReference = 3721CD94A49F9FE9A71B4B06 /* Pods-aerogear-otp.iosTests.debug.xcconfig */;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				GCC_NO_COMMON_BLOCKS = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "aerogear-otp.ios/aerogear-otp.ios-Prefix.pch";
 				INFOPLIST_FILE = "aerogear-otp.iosTests/aerogear-otp.iosTests-Info.plist";


### PR DESCRIPTION
Sorry, this automatic recommended setting was not allowing the tests to run from Xcode, so I've disabled it.